### PR TITLE
fix: properly defer metrics exporter shutdown

### DIFF
--- a/main.go
+++ b/main.go
@@ -29,8 +29,7 @@ func createIntCounter(meter metric.Meter, name string, description string) metri
 }
 
 func initMetricsExporter(ctx context.Context) (*otlpmetric.Exporter, error) {
-	client := otlpmetricgrpc.NewClient(otlpmetricgrpc.WithInsecure())
-	exp, err := otlpmetric.New(ctx, client)
+	exp, err := otlpmetricgrpc.New(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create the collector exporter: %v", err)
 	}

--- a/main.go
+++ b/main.go
@@ -75,7 +75,6 @@ func readFromPipe() ([]byte, error) {
 			return nil, err
 		}
 
-		fmt.Println(string(buf))
 		return buf, nil
 	}
 


### PR DESCRIPTION
## What does this PR do?
It moves the shutdown of the metrics exporter to the right place, as it was causing a context cancellation before sending any metric

We are removing a print of the piped input, which was there for debugging purpose

