### PR TITLE
chore: dockerise tool

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.git
+.github
+demos
+build
+dist
+testresources
+
+.env
+.gitignore
+.goreleaser.yml
+*_test.go
+
+junit2otlp
+Makefile
+TEST-*.xml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+############################
+# STEP 1 build executable binary
+############################
+FROM golang:alpine AS builder
+# Install git.
+# Git is required for fetching the dependencies.
+RUN apk update && apk add --no-cache ca-certificates git
+WORKDIR $GOPATH/src/github.com/mdelapenya/junit2otlp
+
+COPY . .
+
+# Build the binary.
+RUN GOOS=linux GOARCH=386 go build -ldflags="-w -s" -o /go/bin/junit2otlp
+############################
+# STEP 2 build a small image
+############################
+FROM scratch
+# Copy default certificates
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+# Copy our static executable.
+COPY --from=builder /go/bin/junit2otlp /go/bin/junit2otlp
+# Run the junit2otlp binary.
+ENTRYPOINT ["/go/bin/junit2otlp"]
+CMD [""]

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,9 @@ define stop_demo
 	rm -fr demos/$(1)/build
 endef
 
+buildDockerImage:
+	docker build -t mdelapenya/junit2otlp:latest .
+
 demo-start-elastic:
 	$(call setup_demo_env,elastic)
 	$(call start_demo,elastic)

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ define stop_demo
 	rm -fr demos/$(1)/build
 endef
 
-buildDockerImage:
+build-docker-image:
 	docker build -t mdelapenya/junit2otlp:latest .
 
 demo-start-elastic:

--- a/README.md
+++ b/README.md
@@ -18,6 +18,28 @@ This tool is able to override the following attributes:
 
 For further reference on environment variables in the OpenTelemetry SDK, please read the [official specification](https://opentelemetry.io/docs/reference/specification/sdk-environment-variables/)
 
+## Docker image
+It's possible to run the binary as a Docker image. To build and use the image
+
+1. First build the Docker image using this Make goal:
+```shell
+make buildDockerImage
+```
+
+2. Then start the Elastic Stack back-end:
+```shell
+make demo-start-elastic
+```
+
+3. Finally, once the services are started, run:
+```
+cat TEST-sample3.xml | docker run --rm -i --network elastic_junit2otlp --env OTEL_EXPORTER_OTLP_ENDPOINT=http://apm-server:8200 mdelapenya/junit2otlp:latest --service-name DOCKERFOO --trace-name TRACEBAR
+```
+  - We are making the Docker container receive the pipe with the `-i` flag.
+  - We are attaching the container to the same Docker network where the services are running.
+  - We are passing an environment variable with the URL of the OpenTelemetry exporter endpoint, in this case an APM Server instance.
+  - We are passing command line flags to the container, setting the service name (_DOCKERFOO_) and the trace name (_TRACEBAR_).
+
 ## Demos
 To demonstrate how traces and metrics are sent to different back-ends, we are provising the following demos:
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ It's possible to run the binary as a Docker image. To build and use the image
 
 1. First build the Docker image using this Make goal:
 ```shell
-make buildDockerImage
+make build-docker-image
 ```
 
 2. Then start the Elastic Stack back-end:

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This tool is able to override the following attributes:
 | --------- | ---- | ------------- | ----------- |
 | Service Name | --service-name | `junit2otlp` | Overrides OpenTelemetry's service name. If the `OTEL_SERVICE_NAME` environment variable is set, it will take precedence over any other value. |
 | Service Version | --service-version | Empty | Overrides OpenTelemetry's service version. If the `OTEL_SERVICE_VERSION` environment variable is set, it will take precedence over any other value. |
+| Trace Name | --trace-name | `junit2otlp` | Overrides OpenTelemetry's trace name. |
 
 For further reference on environment variables in the OpenTelemetry SDK, please read the [official specification](https://opentelemetry.io/docs/reference/specification/sdk-environment-variables/)
 


### PR DESCRIPTION
## What is this PR doing?
It supports building a Docker image for the tool, that could be used to read XML files from pipes:

```shell
cat TEST-sample3.xml | docker run --rm -i --network elastic_junit2otlp --env OTEL_EXPORTER_OTLP_ENDPOINT=http://apm-server:8200 mdelapenya/junit2otlp:latest --service-name DOCKERFOO --trace-name TRACEBAR
```

