### PR TITLE
feat: support contributing authors and committers

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ For each test execution, represented by a test report file, the tool will add th
 | `tests.passed` | Number of passed tests in the test execution |
 | `tests.skipped` | Number of skipped tests in the test execution |
 | `tests.duration` | Duration of the test execution |
+| `tests.suitename` | Name of the test execution |
 | `tests.systemerr` | Log produced by Systemerr |
 | `tests.systemout` | Log produced by Systemout |
 | `tests.total` | Total number of tests in the test execution |

--- a/README.md
+++ b/README.md
@@ -17,6 +17,67 @@ This tool is able to override the following attributes:
 
 For further reference on environment variables in the OpenTelemetry SDK, please read the [official specification](https://opentelemetry.io/docs/reference/specification/sdk-environment-variables/)
 
+## OpenTelemetry Attributes
+This tool is going to parse the XML report produced by jUnit, or any other tool converting to that format, adding different attributes, separated by different categories:
+
+- Test metrics attributes
+- Ownership attributes
+
+### Test metrics attributes
+These attributes are added as metrics.
+#### Test execution metrics
+For each test execution, represented by a test report file, the tool will add the following attributes to the metric document
+
+| Attribute | Description |
+| --------- | ----------- |
+| `tests.failed` | Number of failed tests in the test execution |
+| `tests.error` | Number of errored tests in the test execution |
+| `tests.passed` | Number of passed tests in the test execution |
+| `tests.skipped` | Number of skipped tests in the test execution |
+| `tests.duration` | Duration of the test execution |
+| `tests.systemerr` | Log produced by Systemerr |
+| `tests.systemout` | Log produced by Systemout |
+| `tests.total` | Total number of tests in the test execution |
+
+#### Test suite metrics
+For each test suite in the test execution, the tool will add the following attributes to the metric document:
+
+| Attribute | Description |
+| --------- | ----------- |
+| `test.classname` | Classname or file for the test suite |
+| `test.duration` | Duration of the test suite |
+| `test.message` | Message of the test suite |
+| `test.status` | Status of the test suite |
+| `test.systemerr` | Log produced by Systemerr |
+| `test.systemout` | Log produced by Systemout |
+
+### Ownership attributes
+These attributes are added to the traces and spans sent by the tool, identifying the owner (or owners) of the test suite, trying to correlate a test failure with an author or authors. To identify the owner, the tool will inspect the SCM repository for the project:
+
+- if it's a change request (pull request on Github, merge request on Gitlab), it will a
+#### SCM attributes
+Because the XML test report is evaluated for a project **in a SCM repository**, the tool will add the following attributes to each trace and span:
+
+| Attribute | Description |
+| --------- | ----------- |
+| `scm.authors` | Array of unique Email addresses for the authors of the commits |
+| `scm.branch` | Name of the branch where the test execution is processed |
+| `scm.committers` | Array of unique Email addresses for the committers of the commits |
+| `scm.provider` | Optional. If present, will include the name of the SCM provider, such as Github, Gitlab, Bitbucket, etc. |
+| `scm.repository` | Array of unique URLs representing the repository (i.e. https://github.com/mdelapenya/junit2otlp) |
+| `scm.type` | Type of the SCM (i.e. git, svn, mercurial)  At this moment the tool only supports Git repositories. |
+
+#### Change request attributes
+The tool will add the following attributes to each trace and span if and only if the XML test report is evaluated in the context of a change requests **for a Git repository**:
+
+| Attribute | Description |
+| --------- | ----------- |
+| `scm.git.additions` | Number of added lines in the changeset |
+| `scm.git.deletions` | Number of deleted lines in the changeset |
+| `scm.git.files.modified` | Number of modified files in the changeset |
+
+A changeset is calculated based on the HEAD commit and the first ancestor between HEAD and the branch where the changeset is submitted against.
+
 ## Demos
 To demonstrate how traces and metrics are sent to different back-ends, we are provising the following demos:
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ For each test suite in the test execution, the tool will add the following attri
 | --------- | ----------- |
 | `test.classname` | Classname or file for the test suite |
 | `test.duration` | Duration of the test suite |
+| `test.error` | Error message of the test suite |
 | `test.message` | Message of the test suite |
 | `test.status` | Status of the test suite |
 | `test.systemerr` | Log produced by Systemerr |

--- a/README.md
+++ b/README.md
@@ -52,9 +52,8 @@ For each test suite in the test execution, the tool will add the following attri
 | `test.systemout` | Log produced by Systemout |
 
 ### Ownership attributes
-These attributes are added to the traces and spans sent by the tool, identifying the owner (or owners) of the test suite, trying to correlate a test failure with an author or authors. To identify the owner, the tool will inspect the SCM repository for the project:
+These attributes are added to the traces and spans sent by the tool, identifying the owner (or owners) of the test suite, trying to correlate a test failure with an author or authors. To identify the owner, the tool will inspect the SCM repository for the project.
 
-- if it's a change request (pull request on Github, merge request on Gitlab), it will a
 #### SCM attributes
 Because the XML test report is evaluated for a project **in a SCM repository**, the tool will add the following attributes to each trace and span:
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ The tool will add the following attributes to each trace and span if and only if
 | --------- | ----------- |
 | `scm.git.additions` | Number of added lines in the changeset |
 | `scm.git.deletions` | Number of deleted lines in the changeset |
+| `scm.git.clone.depth` | Depth of the git clone |
+| `scm.git.clone.shallow` | Whethere the git clone was shallow or not |
 | `scm.git.files.modified` | Number of modified files in the changeset |
 
 A changeset is calculated based on the HEAD commit and the first ancestor between HEAD and the branch where the changeset is submitted against.

--- a/git.go
+++ b/git.go
@@ -1,7 +1,13 @@
 package main
 
 import (
+	"fmt"
+	"os"
+
 	git "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/pkg/errors"
 	"go.opentelemetry.io/otel/attribute"
 )
 
@@ -12,7 +18,7 @@ type GitScm struct {
 // contributeAttributes this method never fails, returning the current state of the contributed attributes
 // at the moment of the failure
 func (scm *GitScm) contributeAttributes() []attribute.KeyValue {
-	repository, err := git.PlainOpen(scm.repositoryPath)
+	repository, err := scm.openLocalRepository()
 	if err != nil {
 		return []attribute.KeyValue{}
 	}
@@ -34,5 +40,122 @@ func (scm *GitScm) contributeAttributes() []attribute.KeyValue {
 	}
 	gitAttributes = append(gitAttributes, attribute.Key(ScmBranch).String(branch.Name().String()))
 
+	contributions := []func(*git.Repository) ([]attribute.KeyValue, error){
+		contributeCommitters,
+	}
+
+	for _, contribution := range contributions {
+		contributtedAttributes, err := contribution(repository)
+		if err != nil {
+			fmt.Printf(">> not contributing attributes: %v", err)
+			continue
+		}
+
+		gitAttributes = append(gitAttributes, contributtedAttributes...)
+	}
+
 	return gitAttributes
+}
+
+// contributeCommitters this method calculates the commits between current branch (HEAD) and a target branch.
+// - The target branch has to be set as the TARGET_BRANCH environment variable
+// - HEAD branch must be a valid branch in the git repository
+// The algorithm will look for the first ancestor between HEAD and the TARGET_BRANCH, and will iterate through
+// the list of commits, storing the author and the committer for each commit, contributing an array of Strings
+// attribute including the email of the author/commiter.
+// This method will return the current state of the contributed attributes at the moment of an eventual failure.
+func contributeCommitters(repository *git.Repository) (attributes []attribute.KeyValue, outError error) {
+	attributes = []attribute.KeyValue{}
+
+	targetBranchEnv := os.Getenv("TARGET_BRANCH")
+	if targetBranchEnv == "" {
+		outError = fmt.Errorf("not processing committers because we are not able to calculate the target branch. Please set the TARGET_BRANCH variable with the name of the branch where you want to merge current branch")
+		return
+	}
+
+	targetBranch, err := repository.Branch(targetBranchEnv)
+	if err != nil {
+		outError = errors.Wrapf(err, "not able to retrieve the %s TARGET_BRANCH: %v", targetBranchEnv, err)
+		return
+	}
+
+	targetRef, err := repository.ResolveRevision(plumbing.Revision(targetBranch.Merge))
+	if err != nil {
+		outError = errors.Wrapf(err, "not able to retrieve ref from TARGET_BRANCH: %v", err)
+		return
+	}
+
+	targetCommit, err := repository.CommitObject(*targetRef)
+	if err != nil {
+		outError = errors.Wrapf(err, "not able to retrieve commit from TARGET_BRANCH: %v", err)
+		return
+	}
+
+	headRef, err := repository.Head()
+	if err != nil {
+		outError = errors.Wrapf(err, "not able to retrieve ref from HEAD: %v", err)
+		return
+	}
+
+	headCommit, err := repository.CommitObject(headRef.Hash())
+	if err != nil {
+		outError = errors.Wrapf(err, "not able to retrieve commit from HEAD: %v", err)
+		return
+	}
+
+	commits, err := headCommit.MergeBase(targetCommit)
+	if err != nil {
+		outError = errors.Wrapf(err, "not able to find a common ancestor between HEAD and TARGET_BRANCH: %v", err)
+		return
+	}
+
+	if len(commits) == 0 {
+		outError = errors.Wrapf(err, "not able to find a common ancestor between HEAD and TARGET_BRANCH: %v", err)
+		return
+	}
+
+	ancestor := commits[0]
+
+	commitsIterator, err := repository.Log(&git.LogOptions{From: headCommit.Hash, Since: &ancestor.Author.When})
+	if err != nil {
+		outError = errors.Wrapf(err, "not able to retrieve commits between HEAD and TARGET_BRANCH: %v", err)
+		return
+	}
+
+	authors := map[string]bool{}
+	committers := map[string]bool{}
+
+	commitsIterator.ForEach(func(c *object.Commit) error {
+		authors[c.Author.Email] = true
+		committers[c.Committer.Email] = true
+		return nil
+	})
+
+	if len(authors) > 0 {
+		attributes = append(attributes, attribute.Key(ScmAuthors).StringSlice(mapToArray(authors)))
+	}
+
+	if len(committers) > 0 {
+		attributes = append(attributes, attribute.Key(ScmCommitters).StringSlice(mapToArray(committers)))
+	}
+
+	return
+}
+
+func mapToArray(m map[string]bool) []string {
+	array := []string{}
+	for k := range m {
+		array = append(array, k)
+	}
+
+	return array
+}
+
+func (scm *GitScm) openLocalRepository() (*git.Repository, error) {
+	repository, err := git.PlainOpen(scm.repositoryPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return repository, nil
 }

--- a/git.go
+++ b/git.go
@@ -40,9 +40,6 @@ func NewGitScm(repositoryPath string) *GitScm {
 	scm.isRequest = request
 	scm.provider = gitProvider
 
-	fmt.Printf(">> HEAD SHA: %s", headSha)
-	fmt.Printf(">> BASE_REF: %s", baseRef)
-
 	return scm
 }
 
@@ -169,9 +166,6 @@ func (scm *GitScm) contributeAttributes() []attribute.KeyValue {
 // This method will return the current state of the contributed attributes at the moment of an eventual failure.
 func (scm *GitScm) contributeCommitters(headCommit *object.Commit, targetCommit *object.Commit) (attributes []attribute.KeyValue, outError error) {
 	attributes = []attribute.KeyValue{}
-
-	fmt.Printf(">>> HEAD commit: %v", headCommit)
-	fmt.Printf(">>> TARGET commit: %v", targetCommit)
 
 	commits, err := headCommit.MergeBase(targetCommit)
 	if err != nil {

--- a/git.go
+++ b/git.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"time"
 
 	git "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
@@ -180,7 +181,8 @@ func (scm *GitScm) contributeCommitters(headCommit *object.Commit, targetCommit 
 
 	ancestor := commits[0]
 
-	commitsIterator, err := scm.repository.Log(&git.LogOptions{From: headCommit.Hash, Since: &ancestor.Author.When})
+	when := ancestor.Author.When.Add(time.Millisecond * 1) // adding one millisecond to avoid including the ancestor in the log
+	commitsIterator, err := scm.repository.Log(&git.LogOptions{From: headCommit.Hash, Since: &when})
 	if err != nil {
 		outError = errors.Wrapf(err, "not able to retrieve commits between HEAD and TARGET_BRANCH: %v", err)
 		return
@@ -225,7 +227,7 @@ func (scm *GitScm) contributeFilesAndLines(headCommit *object.Commit, targetComm
 		return
 	}
 
-	patch, err := headTree.Patch(targetTree)
+	patch, err := targetTree.Patch(headTree)
 	if err != nil {
 		outError = errors.Wrapf(err, "not able to find the pathc between HEAD and TARGET_BRANCH trees: %v", err)
 		return

--- a/git.go
+++ b/git.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"os"
 
 	git "github.com/go-git/go-git/v5"
@@ -38,8 +37,8 @@ func NewGitScm(repositoryPath string) *GitScm {
 	scm.baseRef = baseRef
 	scm.provider = gitProvider
 
-	log.Printf(">> HEAD SHA: %s", headSha)
-	log.Printf(">> TARGET_BRANCH: %s", baseRef)
+	fmt.Printf(">> HEAD SHA: %s", headSha)
+	fmt.Printf(">> BASE_REF: %s", baseRef)
 
 	return scm
 }

--- a/git.go
+++ b/git.go
@@ -9,9 +9,9 @@ type GitScm struct {
 	repositoryPath string
 }
 
-// contributeOtelAttributes this method never fails, returning the current state of the contributed attributes
+// contributeAttributes this method never fails, returning the current state of the contributed attributes
 // at the moment of the failure
-func (scm *GitScm) contributeOtelAttributes() []attribute.KeyValue {
+func (scm *GitScm) contributeAttributes() []attribute.KeyValue {
 	repository, err := git.PlainOpen(scm.repositoryPath)
 	if err != nil {
 		return []attribute.KeyValue{}

--- a/git.go
+++ b/git.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"os"
 
 	git "github.com/go-git/go-git/v5"
@@ -85,6 +86,9 @@ func (scm *GitScm) contributeAttributes() []attribute.KeyValue {
 	}
 
 	headSha, targetBranchEnv, gitProvider := checkGitProvider()
+
+	log.Printf(">> HEAD SHA: %s", headSha)
+	log.Printf(">> TARGET_BRANCH: %s", targetBranchEnv)
 
 	// from now on, this is a Git repository
 	gitAttributes := []attribute.KeyValue{

--- a/git.go
+++ b/git.go
@@ -106,6 +106,9 @@ func (scm *GitScm) contributeAttributes() []attribute.KeyValue {
 func contributeCommitters(repository *git.Repository, headCommit *object.Commit, targetCommit *object.Commit) (attributes []attribute.KeyValue, outError error) {
 	attributes = []attribute.KeyValue{}
 
+	fmt.Printf(">>> HEAD commit: %v", headCommit)
+	fmt.Printf(">>> TARGET commit: %v", targetCommit)
+
 	commits, err := headCommit.MergeBase(targetCommit)
 	if err != nil {
 		outError = errors.Wrapf(err, "not able to find a common ancestor between HEAD and TARGET_BRANCH: %v", err)

--- a/git.go
+++ b/git.go
@@ -47,38 +47,34 @@ func NewGitScm(repositoryPath string) *GitScm {
 // - The target branch has to be set as the TARGET_BRANCH environment variable
 // - HEAD branch must be a valid branch in the git repository
 func (scm *GitScm) calculateCommits() (*object.Commit, *object.Commit, error) {
-	repository := scm.repository
-	headSha := scm.headSha
-	targetBranchEnv := scm.baseRef
-
-	targetBranch, err := repository.Branch(targetBranchEnv)
+	targetBranch, err := scm.repository.Branch(scm.baseRef)
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "not able to retrieve the %s TARGET_BRANCH: %v", targetBranchEnv, err)
+		return nil, nil, errors.Wrapf(err, "not able to retrieve the %s TARGET_BRANCH: %v", scm.baseRef, err)
 	}
 
-	targetRef, err := repository.ResolveRevision(plumbing.Revision(targetBranch.Merge))
+	targetRef, err := scm.repository.ResolveRevision(plumbing.Revision(targetBranch.Merge))
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "not able to retrieve ref from TARGET_BRANCH: %v", err)
 	}
 
-	targetCommit, err := repository.CommitObject(*targetRef)
+	targetCommit, err := scm.repository.CommitObject(*targetRef)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "not able to retrieve commit from TARGET_BRANCH: %v", err)
 	}
 
 	var headRefSha plumbing.Hash
-	if headSha == "" {
-		headRef, err := repository.Head()
+	if scm.headSha == "" {
+		headRef, err := scm.repository.Head()
 		if err != nil {
 			return nil, nil, errors.Wrapf(err, "not able to retrieve ref from HEAD: %v", err)
 		}
 
 		headRefSha = headRef.Hash()
 	} else {
-		headRefSha = plumbing.NewHash(headSha)
+		headRefSha = plumbing.NewHash(scm.headSha)
 	}
 
-	headCommit, err := repository.CommitObject(headRefSha)
+	headCommit, err := scm.repository.CommitObject(headRefSha)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "not able to retrieve commit from HEAD: %v", err)
 	}

--- a/git.go
+++ b/git.go
@@ -121,6 +121,19 @@ func (scm *GitScm) contributeAttributes() []attribute.KeyValue {
 		gitAttributes = append(gitAttributes, attribute.Key(ScmProvider).String(scm.provider))
 	}
 
+	shallow, err := scm.repository.Storer.Shallow()
+	if err != nil {
+		return gitAttributes
+	}
+
+	if shallow == nil {
+		gitAttributes = append(gitAttributes, attribute.Key(GitCloneShallow).Bool(false))
+		gitAttributes = append(gitAttributes, attribute.Key(GitCloneDepth).Int(0))
+	} else {
+		gitAttributes = append(gitAttributes, attribute.Key(GitCloneShallow).Bool(len(shallow) != 0))
+		gitAttributes = append(gitAttributes, attribute.Key(GitCloneDepth).Int(len(shallow)))
+	}
+
 	origin, err := scm.repository.Remote("origin")
 	if err != nil {
 		return gitAttributes

--- a/git.go
+++ b/git.go
@@ -142,7 +142,12 @@ func (scm *GitScm) contributeAttributes() []attribute.KeyValue {
 	}
 
 	contributions := []func(*object.Commit, *object.Commit) ([]attribute.KeyValue, error){
-		scm.contributeCommitters, scm.contributeFilesAndLines,
+		scm.contributeCommitters,
+	}
+
+	if scm.isRequest {
+		// calculate modified lines for pull/merge requests
+		contributions = append(contributions, scm.contributeFilesAndLines)
 	}
 
 	for _, contribution := range contributions {

--- a/git.go
+++ b/git.go
@@ -26,7 +26,7 @@ func (scm *GitScm) contributeOtelAttributes() []attribute.KeyValue {
 	if err != nil {
 		return gitAttributes
 	}
-	gitAttributes = append(gitAttributes, attribute.Key(ScmRepository).String(origin.Config().URLs[0]))
+	gitAttributes = append(gitAttributes, attribute.Key(ScmRepository).StringSlice(origin.Config().URLs))
 
 	branch, err := repository.Head()
 	if err != nil {

--- a/git.go
+++ b/git.go
@@ -15,7 +15,7 @@ import (
 type GitScm struct {
 	baseRef        string
 	headSha        string
-	isRequest      bool // if the tool is evaluating a pull/merge request or a branch
+	changeRequest  bool // if the tool is evaluating a change request or a branch
 	provider       string
 	repository     *git.Repository
 	repositoryPath string
@@ -33,11 +33,11 @@ func NewGitScm(repositoryPath string) *GitScm {
 
 	scm.repository = repository
 
-	headSha, baseRef, gitProvider, request := checkGitProvider()
+	headSha, baseRef, gitProvider, changeRequest := checkGitProvider()
 
 	scm.headSha = headSha
 	scm.baseRef = baseRef
-	scm.isRequest = request
+	scm.changeRequest = changeRequest
 	scm.provider = gitProvider
 
 	return scm
@@ -142,7 +142,7 @@ func (scm *GitScm) contributeAttributes() []attribute.KeyValue {
 		scm.contributeCommitters,
 	}
 
-	if scm.isRequest {
+	if scm.changeRequest {
 		// calculate modified lines for pull/merge requests
 		contributions = append(contributions, scm.contributeFilesAndLines)
 	}

--- a/git_test.go
+++ b/git_test.go
@@ -18,7 +18,7 @@ func TestGit(t *testing.T) {
 		repositoryPath: workingDir,
 	}
 
-	atts := scm.contributeOtelAttributes()
+	atts := scm.contributeAttributes()
 
 	assert.Equal(t, 3, len(atts))
 

--- a/git_test.go
+++ b/git_test.go
@@ -32,6 +32,51 @@ func TestGit(t *testing.T) {
 	}, "Remote is not set as scm.repository. Attributes: %v", atts)
 }
 
+func TestGit_ContributeCommitters(t *testing.T) {
+	os.Setenv("TARGET_BRANCH", "main")
+	defer os.Unsetenv("TARGET_BRANCH")
+
+	workingDir, err := os.Getwd()
+	if err != nil {
+		t.Error()
+	}
+
+	scm := &GitScm{
+		repositoryPath: workingDir,
+	}
+
+	repository, err := scm.openLocalRepository()
+	if err != nil {
+		t.Error()
+	}
+
+	// TODO: verify attributes in a consistent manner on the CI. UNtil then, check there are no errors
+	_, err = contributeCommitters(repository)
+	if err != nil {
+		t.Error()
+	}
+}
+
+func TestGit_ContributeCommittersWithoutTargetBranch(t *testing.T) {
+	workingDir, err := os.Getwd()
+	if err != nil {
+		t.Error()
+	}
+
+	scm := &GitScm{
+		repositoryPath: workingDir,
+	}
+
+	repository, err := readRepository(scm)
+	if err != nil {
+		t.Error()
+	}
+
+	atts, err := contributeCommitters(repository)
+	assert.NotNil(t, err)
+	assert.Empty(t, atts)
+}
+
 func keyExists(t *testing.T, attributes []attribute.KeyValue, key string) bool {
 	for _, att := range attributes {
 		if string(att.Key) == key {

--- a/git_test.go
+++ b/git_test.go
@@ -20,9 +20,9 @@ func TestGit(t *testing.T) {
 
 	atts := scm.contributeAttributes()
 
-	assert.Equal(t, 3, len(atts))
-
+	assert.Condition(t, func() bool { return keyExists(t, atts, ScmAuthors) }, "Authors is not set as scm.authors. Attributes: %v", atts)
 	assert.Condition(t, func() bool { return keyExists(t, atts, ScmBranch) }, "Branch is not set as scm.branch. Attributes: %v", atts)
+	assert.Condition(t, func() bool { return keyExists(t, atts, ScmCommitters) }, "Committers is not set as scm.committers. Attributes: %v", atts)
 	assert.Condition(t, func() bool {
 		return keyExistsWithValue(t, atts, ScmType, "git")
 	}, "Git is not set as scm.type. Attributes: %v", atts)

--- a/git_test.go
+++ b/git_test.go
@@ -15,9 +15,10 @@ func TestCheckGitProvider(t *testing.T) {
 		defer os.Unsetenv("GITHUB_SHA")
 		defer os.Unsetenv("GITHUB_BASE_REF")
 
-		sha, baseRef := checkGitProvider()
+		sha, baseRef, provider := checkGitProvider()
 		assert.Equal(t, "0123456", sha)
 		assert.Equal(t, "main", baseRef)
+		assert.Equal(t, "Github", provider)
 	})
 
 	t.Run("Running on Gitlab", func(t *testing.T) {
@@ -26,23 +27,26 @@ func TestCheckGitProvider(t *testing.T) {
 		defer os.Unsetenv("CI_MERGE_REQUEST_SOURCE_BRANCH_SHA")
 		defer os.Unsetenv("CI_MERGE_REQUEST_TARGET_BRANCH_NAME")
 
-		sha, baseRef := checkGitProvider()
+		sha, baseRef, provider := checkGitProvider()
 		assert.Equal(t, "0123456", sha)
 		assert.Equal(t, "main", baseRef)
+		assert.Equal(t, "Gitlab", provider)
 	})
 
 	t.Run("Running on Local machine with TARGET_BRANCH", func(t *testing.T) {
 		os.Setenv("TARGET_BRANCH", "main")
 		defer os.Unsetenv("TARGET_BRANCH")
-		sha, baseRef := checkGitProvider()
+		sha, baseRef, provider := checkGitProvider()
 		assert.Equal(t, "", sha)
 		assert.Equal(t, "main", baseRef)
+		assert.Equal(t, "", provider)
 	})
 
 	t.Run("Running on Local machine without TARGET_BRANCH", func(t *testing.T) {
-		sha, baseRef := checkGitProvider()
+		sha, baseRef, provider := checkGitProvider()
 		assert.Equal(t, "", sha)
 		assert.Equal(t, "", baseRef)
+		assert.Equal(t, "", provider)
 	})
 }
 
@@ -119,7 +123,9 @@ func TestGit_ContributeCommitters(t *testing.T) {
 		t.Error()
 	}
 
-	headCommit, targetCommit, err := calculateCommits(repository)
+	headSha, targetBranchEnv, _ := checkGitProvider()
+
+	headCommit, targetCommit, err := calculateCommits(repository, headSha, targetBranchEnv)
 	if err != nil {
 		t.Error()
 	}
@@ -149,7 +155,9 @@ func TestGit_ContributeFilesAndLines(t *testing.T) {
 		t.Error()
 	}
 
-	headCommit, targetCommit, err := calculateCommits(repository)
+	headSha, targetBranchEnv, _ := checkGitProvider()
+
+	headCommit, targetCommit, err := calculateCommits(repository, headSha, targetBranchEnv)
 	if err != nil {
 		t.Error()
 	}
@@ -179,7 +187,9 @@ func TestGit_CalculateCommitsWithTargetBranch(t *testing.T) {
 		t.Error()
 	}
 
-	headCommit, targetCommit, err := calculateCommits(repository)
+	headSha, targetBranchEnv, _ := checkGitProvider()
+
+	headCommit, targetCommit, err := calculateCommits(repository, headSha, targetBranchEnv)
 	if err != nil {
 		t.Error()
 	}
@@ -203,7 +213,9 @@ func TestGit_CalculateCommitsWithoutTargetBranch(t *testing.T) {
 		t.Error()
 	}
 
-	headCommit, targetCommit, err := calculateCommits(repository)
+	headSha, targetBranchEnv, _ := checkGitProvider()
+
+	headCommit, targetCommit, err := calculateCommits(repository, headSha, targetBranchEnv)
 	if err == nil {
 		t.Error()
 	}

--- a/git_test.go
+++ b/git_test.go
@@ -109,9 +109,7 @@ func TestGit_ContributeCommitters(t *testing.T) {
 
 	scm := NewGitScm(workingDir)
 
-	headSha, targetBranchEnv, _ := checkGitProvider()
-
-	headCommit, targetCommit, err := calculateCommits(scm.repository, headSha, targetBranchEnv)
+	headCommit, targetCommit, err := scm.calculateCommits()
 	if err != nil {
 		t.Error()
 	}
@@ -129,9 +127,7 @@ func TestGit_ContributeFilesAndLines(t *testing.T) {
 
 	scm := NewGitScm(workingDir)
 
-	headSha, targetBranchEnv, _ := checkGitProvider()
-
-	headCommit, targetCommit, err := calculateCommits(scm.repository, headSha, targetBranchEnv)
+	headCommit, targetCommit, err := scm.calculateCommits()
 	if err != nil {
 		t.Error()
 	}
@@ -149,9 +145,7 @@ func TestGit_CalculateCommitsWithTargetBranch(t *testing.T) {
 
 	scm := NewGitScm(workingDir)
 
-	headSha, targetBranchEnv, _ := checkGitProvider()
-
-	headCommit, targetCommit, err := calculateCommits(scm.repository, headSha, targetBranchEnv)
+	headCommit, targetCommit, err := scm.calculateCommits()
 	if err != nil {
 		t.Error()
 	}
@@ -163,9 +157,7 @@ func TestGit_CalculateCommitsWithTargetBranch(t *testing.T) {
 func TestGit_CalculateCommitsWithoutTargetBranch(t *testing.T) {
 	scm := NewGitScm(workingDir)
 
-	headSha, targetBranchEnv, _ := checkGitProvider()
-
-	headCommit, targetCommit, err := calculateCommits(scm.repository, headSha, targetBranchEnv)
+	headCommit, targetCommit, err := scm.calculateCommits()
 	if err == nil {
 		t.Error()
 	}

--- a/git_test.go
+++ b/git_test.go
@@ -93,6 +93,36 @@ func TestGit_ContributeCommitters(t *testing.T) {
 	}
 }
 
+func TestGit_ContributeFilesAndLines(t *testing.T) {
+	os.Setenv("TARGET_BRANCH", "main")
+	defer os.Unsetenv("TARGET_BRANCH")
+
+	workingDir, err := os.Getwd()
+	if err != nil {
+		t.Error()
+	}
+
+	scm := &GitScm{
+		repositoryPath: workingDir,
+	}
+
+	repository, err := scm.openLocalRepository()
+	if err != nil {
+		t.Error()
+	}
+
+	headCommit, targetCommit, err := calculateCommits(repository)
+	if err != nil {
+		t.Error()
+	}
+
+	// TODO: verify attributes in a consistent manner on the CI. Until then, check there are no errors
+	_, err = contributeFilesAndLines(repository, headCommit, targetCommit)
+	if err != nil {
+		t.Error()
+	}
+}
+
 func TestGit_CalculateCommitsWithTargetBranch(t *testing.T) {
 	os.Setenv("TARGET_BRANCH", "main")
 	defer os.Unsetenv("TARGET_BRANCH")

--- a/git_test.go
+++ b/git_test.go
@@ -299,9 +299,13 @@ func TestCheckGitProvider(t *testing.T) {
 	})
 
 	t.Run("Local machine", func(t *testing.T) {
+		cleanGithubFn()
+
 		t.Run("Running with TARGET_BRANCH", func(t *testing.T) {
 			os.Setenv("TARGET_BRANCH", "main")
+			defer restoreGithubFn()
 			defer os.Unsetenv("TARGET_BRANCH")
+
 			sha, baseRef, provider, changeRequest := checkGitProvider()
 			assert.Equal(t, "", sha)
 			assert.Equal(t, "main", baseRef)
@@ -310,6 +314,8 @@ func TestCheckGitProvider(t *testing.T) {
 		})
 
 		t.Run("Running without TARGET_BRANCH", func(t *testing.T) {
+			defer restoreGithubFn()
+
 			sha, baseRef, provider, changeRequest := checkGitProvider()
 			assert.Equal(t, "", sha)
 			assert.Equal(t, "", baseRef)

--- a/git_test.go
+++ b/git_test.go
@@ -222,6 +222,10 @@ func TestCheckGitProvider(t *testing.T) {
 	}
 
 	t.Run("Github", func(t *testing.T) {
+		if originalCommitBranch != "" {
+			t.Skip("Tests skipped when running on Gitlab")
+		}
+
 		testChangeRequest := false
 
 		testSha := "0123456"
@@ -268,6 +272,10 @@ func TestCheckGitProvider(t *testing.T) {
 	})
 
 	t.Run("Gitlab", func(t *testing.T) {
+		if originalSha != "" {
+			t.Skip("Tests skipped when running on Github")
+		}
+
 		cleanGithubFn()
 
 		t.Run("Running for Branches", func(t *testing.T) {
@@ -299,6 +307,10 @@ func TestCheckGitProvider(t *testing.T) {
 	})
 
 	t.Run("Local machine", func(t *testing.T) {
+		if originalSha != "" {
+			t.Skip("Tests skipped when running on Github")
+		}
+
 		cleanGithubFn()
 
 		t.Run("Running with TARGET_BRANCH", func(t *testing.T) {

--- a/git_test.go
+++ b/git_test.go
@@ -46,8 +46,15 @@ func keyExistsWithValue(t *testing.T, attributes []attribute.KeyValue, key strin
 	for _, att := range attributes {
 		if string(att.Key) == key {
 			for _, v := range value {
-				if att.Value.AsString() == v {
-					return true
+				val := att.Value.AsStringSlice()
+				if len(val) == 0 {
+					return v == att.Value.AsString()
+				}
+
+				for _, vv := range val {
+					if vv == v {
+						return true
+					}
 				}
 			}
 		}

--- a/git_test.go
+++ b/git_test.go
@@ -67,7 +67,7 @@ func TestGit_ContributeCommittersWithoutTargetBranch(t *testing.T) {
 		repositoryPath: workingDir,
 	}
 
-	repository, err := readRepository(scm)
+	repository, err := scm.openLocalRepository()
 	if err != nil {
 		t.Error()
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/joshdk/go-junit v0.0.0-20210226021600-6145f504ca0d
+	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0
 	github.com/testcontainers/testcontainers-go v0.11.1
 	go.opentelemetry.io/otel v1.1.0

--- a/main.go
+++ b/main.go
@@ -59,7 +59,7 @@ func createTracesAndSpans(ctx context.Context, srvName string, tracesProvides *s
 
 	scm := GetScm()
 	if scm != nil {
-		scmAttributes := scm.contributeOtelAttributes()
+		scmAttributes := scm.contributeAttributes()
 		runtimeAttributes = append(runtimeAttributes, scmAttributes...)
 	}
 

--- a/main.go
+++ b/main.go
@@ -78,7 +78,7 @@ func createTracesAndSpans(ctx context.Context, srvName string, tracesProvides *s
 
 		suiteAttributes := []attribute.KeyValue{
 			semconv.CodeNamespaceKey.String(suite.Package),
-			attribute.Key("code.testsuite").String(suite.Name),
+			attribute.Key(TestsSuiteName).String(suite.Name),
 			attribute.Key(TestsSystemErr).String(suite.SystemErr),
 			attribute.Key(TestsSystemOut).String(suite.SystemOut),
 			attribute.Key(TestsDuration).Int64(suite.Totals.Duration.Milliseconds()),

--- a/main.go
+++ b/main.go
@@ -111,7 +111,7 @@ func createTracesAndSpans(ctx context.Context, srvName string, tracesProvides *s
 			testAttributes = append(testAttributes, suiteAttributes...)
 
 			if test.Error != nil {
-				testAttributes = append(testAttributes, attribute.Key("tests.error").String(test.Error.Error()))
+				testAttributes = append(testAttributes, attribute.Key(TestError).String(test.Error.Error()))
 			}
 
 			_, testSpan := tracer.Start(ctx, test.Name,

--- a/main_test.go
+++ b/main_test.go
@@ -96,12 +96,15 @@ func Test_Main(t *testing.T) {
 		t.Error()
 	}
 
-	err = os.Mkdir(path.Join(workingDir, "build"), 0755)
-	if err != nil {
-		t.Error(err)
+	buildDir := path.Join(workingDir, "build")
+	if _, err := os.Stat(buildDir); os.IsNotExist(err) {
+		err = os.Mkdir(buildDir, 0755)
+		if err != nil {
+			t.Error(err)
+		}
 	}
 
-	reportFilePath := path.Join(workingDir, "build", "otel-collector.json")
+	reportFilePath := path.Join(buildDir, "otel-collector.json")
 	reportFile, err := os.Create(reportFilePath)
 	if err != nil {
 		t.Error(err)

--- a/main_test.go
+++ b/main_test.go
@@ -26,10 +26,12 @@ func init() {
 	originalServiceNameFlag = serviceNameFlag
 }
 
-type TestReader struct{}
+type TestReader struct {
+	testFile string
+}
 
 func (tr *TestReader) Read() ([]byte, error) {
-	b, err := ioutil.ReadFile("TEST-sample.xml")
+	b, err := ioutil.ReadFile(tr.testFile)
 	if err != nil {
 		return []byte{}, err
 	}
@@ -87,7 +89,7 @@ func findAttributeInArray(attributes []TestTraceAttribute, key string) (TestTrac
 	return TestTraceAttribute{}, fmt.Errorf("attribute with key '%s' not found", key)
 }
 
-func Test_Main(t *testing.T) {
+func Test_Main_SampleXML(t *testing.T) {
 	ctx := context.Background()
 
 	// create file for otel to store the traces
@@ -193,7 +195,7 @@ func Test_Main(t *testing.T) {
 		os.Setenv(exporterEndpointKey, originalEndpoint)
 	}()
 
-	err = Main(context.Background(), &TestReader{})
+	err = Main(context.Background(), &TestReader{testFile: "TEST-sample.xml"})
 	if err != nil {
 		t.Error()
 	}

--- a/scm.go
+++ b/scm.go
@@ -24,7 +24,5 @@ func GetScm() Scm {
 	}
 
 	// .git exists
-	return &GitScm{
-		repositoryPath: workingDir,
-	}
+	return NewGitScm(workingDir)
 }

--- a/scm.go
+++ b/scm.go
@@ -3,12 +3,10 @@ package main
 import (
 	"os"
 	"path"
-
-	"go.opentelemetry.io/otel/attribute"
 )
 
 type Scm interface {
-	contributeOtelAttributes() []attribute.KeyValue
+	OTELAttributesContributor
 }
 
 // GetScm checks if the underlying filesystem repository is a Git repository

--- a/semconv.go
+++ b/semconv.go
@@ -31,6 +31,7 @@ const (
 	// test keys
 	TestClassName = "test.classname"
 	TestDuration  = "test.duration"
+	TestError     = "test.error"
 	TestMessage   = "test.message"
 	TestStatus    = "test.status"
 	TestSystemErr = "test.systemerr"

--- a/semconv.go
+++ b/semconv.go
@@ -24,6 +24,7 @@ const (
 	PassedTestsCount  = "tests.passed"
 	SkippedTestsCount = "tests.skipped"
 	TestsDuration     = "tests.duration"
+	TestsSuiteName    = "tests.suitename"
 	TestsSystemErr    = "tests.systemerr"
 	TestsSystemOut    = "tests.systemout"
 	TotalTestsCount   = "tests.total"

--- a/semconv.go
+++ b/semconv.go
@@ -3,6 +3,11 @@ package main
 const (
 	Junit2otlp = "junit2otlp"
 
+	// git keys
+	GitAdditions     = "scm.git.additions"
+	GitDeletions     = "scm.git.deletions"
+	GitModifiedFiles = "scm.git.files.modified"
+
 	// scm keys
 	ScmAuthors    = "scm.authors"
 	ScmBranch     = "scm.branch"

--- a/semconv.go
+++ b/semconv.go
@@ -12,6 +12,7 @@ const (
 	ScmAuthors    = "scm.authors"
 	ScmBranch     = "scm.branch"
 	ScmCommitters = "scm.committers"
+	ScmProvider   = "scm.provider"
 	ScmRepository = "scm.repository"
 	ScmType       = "scm.type"
 

--- a/semconv.go
+++ b/semconv.go
@@ -4,7 +4,9 @@ const (
 	Junit2otlp = "junit2otlp"
 
 	// scm keys
+	ScmAuthors    = "scm.authors"
 	ScmBranch     = "scm.branch"
+	ScmCommitters = "scm.committers"
 	ScmRepository = "scm.repository"
 	ScmType       = "scm.type"
 

--- a/semconv.go
+++ b/semconv.go
@@ -5,6 +5,8 @@ const (
 
 	// git keys
 	GitAdditions     = "scm.git.additions"
+	GitCloneDepth    = "scm.git.clone.depth"
+	GitCloneShallow  = "scm.git.clone.shallow"
 	GitDeletions     = "scm.git.deletions"
 	GitModifiedFiles = "scm.git.files.modified"
 

--- a/types.go
+++ b/types.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"go.opentelemetry.io/otel/attribute"
+)
+
+type OTELAttributesContributor interface {
+	contributeAttributes() []attribute.KeyValue
+}


### PR DESCRIPTION
## what does this PR do?
It adds the `scm.authors` and `scm.committer` keys, which will be populated from reading the Git diff between the current branch (HEAD) and the first ancestor compared with a target branch.

This target branch must be set in the TARGET_BRANCH environment variable, (i.e. `main`), so that the algorithm is able to get the list of commits between them.

Besides, we are adding specific Git attributes for `scm.git.files.modified`, `scm.git.additions` and `scm.git.deletions`, calculated from the patch between TARGET_BRANCH and HEAD.

Finally, it reads from the current git repository and checks if it's a shallow clone and its depth, adding `scm.git.clone.shallow` and `scm.git.clone.depth`.

## Why is it important?
Adding a correlation between test failures and committers/authors will help in define the ownership of the failures

## Follow-up concerns
- How to deal with merge commits?
- How to deal with complex situations, like push-force?
- Document how to set the target branch so that consumers on CI are able to configure it properly

## Screenshots
<img width="1757" alt="Screenshot 2021-11-25 at 10 20 37" src="https://user-images.githubusercontent.com/951580/143820024-eaf57f33-e672-4f70-96e2-b9b9bacbbe53.png">

