### PR TITLE
chore: enrich attributes with span type, process and scm.baseRef

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Because the XML test report is evaluated for a project **in a SCM repository**, 
 | Attribute | Description |
 | --------- | ----------- |
 | `scm.authors` | Array of unique Email addresses for the authors of the commits |
+| `scm.baseRef` | Name of the target branch (Only for change requests) |
 | `scm.branch` | Name of the branch where the test execution is processed |
 | `scm.committers` | Array of unique Email addresses for the committers of the commits |
 | `scm.provider` | Optional. If present, will include the name of the SCM provider, such as Github, Gitlab, Bitbucket, etc. |

--- a/git.go
+++ b/git.go
@@ -156,6 +156,10 @@ func (scm *GitScm) contributeAttributes() []attribute.KeyValue {
 	}
 
 	if scm.changeRequest {
+		if scm.baseRef != "" {
+			gitAttributes = append(gitAttributes, attribute.Key(ScmBaseRef).String(scm.baseRef))
+		}
+
 		// calculate modified lines for pull/merge requests
 		contributions = append(contributions, scm.contributeFilesAndLines)
 	}

--- a/git_test.go
+++ b/git_test.go
@@ -388,7 +388,7 @@ func TestGit_ContributeAttributesForChangeRequests(t *testing.T) {
 
 	assert.Condition(t, func() bool { return keyExistsWithIntValue(t, atts, GitCloneDepth, 0) }, "should be set as scm.git.clone.depth=0. Attributes: %v", atts)
 	assert.Condition(t, func() bool { return keyExistsWithBoolValue(t, atts, GitCloneShallow, false) }, "should be set as scm.git.clone.shallow=false. Attributes: %v", atts)
-	assert.Condition(t, func() bool { return keyExistsWithValue(t, atts, ScmBaseRef, "main") }, "should be set as scm.baseRef. Attributes: %v", atts)
+	assert.Condition(t, func() bool { return keyExistsWithValue(t, atts, ScmBaseRef, "master") }, "should be set as scm.baseRef. Attributes: %v", atts)
 	assert.Condition(t, func() bool { return keyExistsWithValue(t, atts, ScmBranch, "HEAD") }, "should be set as scm.branch. Attributes: %v", atts)
 	assert.Condition(t, func() bool { return keyExistsWithValue(t, atts, ScmType, "git") }, "Git should be set as scm.type. Attributes: %v", atts)
 	assert.Condition(t, func() bool {
@@ -415,7 +415,7 @@ func TestGit_ContributeAttributesForBranches(t *testing.T) {
 
 	assert.Condition(t, func() bool { return keyExistsWithIntValue(t, atts, GitCloneDepth, 0) }, "should be set as scm.git.clone.depth=0. Attributes: %v", atts)
 	assert.Condition(t, func() bool { return keyExistsWithBoolValue(t, atts, GitCloneShallow, false) }, "should be set as scm.git.clone.shallow=false. Attributes: %v", atts)
-	assert.Condition(t, func() bool { return !keyExistsWithValue(t, atts, ScmBaseRef, "main") }, "should be set as scm.baseRef. Attributes: %v", atts)
+	assert.Condition(t, func() bool { return !keyExistsWithValue(t, atts, ScmBaseRef, "master") }, "should be set as scm.baseRef. Attributes: %v", atts)
 	assert.Condition(t, func() bool { return keyExistsWithValue(t, atts, ScmBranch, "refs/heads/master") }, "Branch should be set as scm.branch. Attributes: %v", atts)
 	assert.Condition(t, func() bool { return keyExistsWithValue(t, atts, ScmType, "git") }, "Git should be set as scm.type. Attributes: %v", atts)
 	assert.Condition(t, func() bool {

--- a/git_test.go
+++ b/git_test.go
@@ -388,6 +388,7 @@ func TestGit_ContributeAttributesForChangeRequests(t *testing.T) {
 
 	assert.Condition(t, func() bool { return keyExistsWithIntValue(t, atts, GitCloneDepth, 0) }, "should be set as scm.git.clone.depth=0. Attributes: %v", atts)
 	assert.Condition(t, func() bool { return keyExistsWithBoolValue(t, atts, GitCloneShallow, false) }, "should be set as scm.git.clone.shallow=false. Attributes: %v", atts)
+	assert.Condition(t, func() bool { return keyExistsWithValue(t, atts, ScmBaseRef, "master") }, "should be set as scm.baseRef. Attributes: %v", atts)
 	assert.Condition(t, func() bool { return keyExistsWithValue(t, atts, ScmBranch, "HEAD") }, "should be set as scm.branch. Attributes: %v", atts)
 	assert.Condition(t, func() bool { return keyExistsWithValue(t, atts, ScmType, "git") }, "Git should be set as scm.type. Attributes: %v", atts)
 	assert.Condition(t, func() bool {
@@ -414,6 +415,7 @@ func TestGit_ContributeAttributesForBranches(t *testing.T) {
 
 	assert.Condition(t, func() bool { return keyExistsWithIntValue(t, atts, GitCloneDepth, 0) }, "should be set as scm.git.clone.depth=0. Attributes: %v", atts)
 	assert.Condition(t, func() bool { return keyExistsWithBoolValue(t, atts, GitCloneShallow, false) }, "should be set as scm.git.clone.shallow=false. Attributes: %v", atts)
+	assert.Condition(t, func() bool { return !keyExistsWithValue(t, atts, ScmBaseRef, "master") }, "should be set as scm.baseRef. Attributes: %v", atts)
 	assert.Condition(t, func() bool { return keyExistsWithValue(t, atts, ScmBranch, "refs/heads/master") }, "Branch should be set as scm.branch. Attributes: %v", atts)
 	assert.Condition(t, func() bool { return keyExistsWithValue(t, atts, ScmType, "git") }, "Git should be set as scm.type. Attributes: %v", atts)
 	assert.Condition(t, func() bool {

--- a/git_test.go
+++ b/git_test.go
@@ -388,7 +388,7 @@ func TestGit_ContributeAttributesForChangeRequests(t *testing.T) {
 
 	assert.Condition(t, func() bool { return keyExistsWithIntValue(t, atts, GitCloneDepth, 0) }, "should be set as scm.git.clone.depth=0. Attributes: %v", atts)
 	assert.Condition(t, func() bool { return keyExistsWithBoolValue(t, atts, GitCloneShallow, false) }, "should be set as scm.git.clone.shallow=false. Attributes: %v", atts)
-	assert.Condition(t, func() bool { return keyExistsWithValue(t, atts, ScmBaseRef, "master") }, "should be set as scm.baseRef. Attributes: %v", atts)
+	assert.Condition(t, func() bool { return keyExistsWithValue(t, atts, ScmBaseRef, "main") }, "should be set as scm.baseRef. Attributes: %v", atts)
 	assert.Condition(t, func() bool { return keyExistsWithValue(t, atts, ScmBranch, "HEAD") }, "should be set as scm.branch. Attributes: %v", atts)
 	assert.Condition(t, func() bool { return keyExistsWithValue(t, atts, ScmType, "git") }, "Git should be set as scm.type. Attributes: %v", atts)
 	assert.Condition(t, func() bool {
@@ -415,7 +415,7 @@ func TestGit_ContributeAttributesForBranches(t *testing.T) {
 
 	assert.Condition(t, func() bool { return keyExistsWithIntValue(t, atts, GitCloneDepth, 0) }, "should be set as scm.git.clone.depth=0. Attributes: %v", atts)
 	assert.Condition(t, func() bool { return keyExistsWithBoolValue(t, atts, GitCloneShallow, false) }, "should be set as scm.git.clone.shallow=false. Attributes: %v", atts)
-	assert.Condition(t, func() bool { return !keyExistsWithValue(t, atts, ScmBaseRef, "master") }, "should be set as scm.baseRef. Attributes: %v", atts)
+	assert.Condition(t, func() bool { return !keyExistsWithValue(t, atts, ScmBaseRef, "main") }, "should be set as scm.baseRef. Attributes: %v", atts)
 	assert.Condition(t, func() bool { return keyExistsWithValue(t, atts, ScmBranch, "refs/heads/master") }, "Branch should be set as scm.branch. Attributes: %v", atts)
 	assert.Condition(t, func() bool { return keyExistsWithValue(t, atts, ScmType, "git") }, "Git should be set as scm.type. Attributes: %v", atts)
 	assert.Condition(t, func() bool {

--- a/main.go
+++ b/main.go
@@ -231,7 +231,7 @@ func Main(ctx context.Context, reader InputReader) error {
 		semconv.ServiceNameKey.String(otlpSrvName),
 		semconv.ServiceVersionKey.String(otlpSrvVersion),
 	)
-	res, err := resource.New(ctx, resAttrs)
+	res, err := resource.New(ctx, resource.WithProcess(), resAttrs)
 	if err != nil {
 		return fmt.Errorf("failed to create OpenTelemetry service name resource: %s", err)
 	}

--- a/main.go
+++ b/main.go
@@ -70,7 +70,7 @@ func createTracesAndSpans(ctx context.Context, srvName string, tracesProvides *s
 	skippedCounter := createIntCounter(meter, SkippedTestsCount, "Total number of skipped tests")
 	testsCounter := createIntCounter(meter, TotalTestsCount, "Total number of executed tests")
 
-	ctx, outerSpan := tracer.Start(ctx, traceNameFlag, trace.WithAttributes(runtimeAttributes...))
+	ctx, outerSpan := tracer.Start(ctx, traceNameFlag, trace.WithAttributes(runtimeAttributes...), trace.WithSpanKind(trace.SpanKindServer))
 	defer outerSpan.End()
 
 	for _, suite := range suites {

--- a/main_test.go
+++ b/main_test.go
@@ -214,11 +214,11 @@ func Test_Main_SampleXML(t *testing.T) {
 
 	resourceSpans := tracesReport.ResourceSpans[0]
 
-	srvNameAttribute := resourceSpans.Resource.Attributes[0]
+	srvNameAttribute, _ := findAttributeInArray(resourceSpans.Resource.Attributes, "service.name")
 	assert.Equal(t, "service.name", srvNameAttribute.Key)
 	assertStringValueInAttribute(t, srvNameAttribute.Value, "jaeger-srv-test")
 
-	srvVersionAttribute := resourceSpans.Resource.Attributes[1]
+	srvVersionAttribute, _ := findAttributeInArray(resourceSpans.Resource.Attributes, "service.version")
 	assert.Equal(t, "service.version", srvVersionAttribute.Key)
 	assertStringValueInAttribute(t, srvVersionAttribute.Value, "")
 

--- a/main_test.go
+++ b/main_test.go
@@ -228,11 +228,13 @@ func Test_Main_SampleXML(t *testing.T) {
 
 	spans := instrumentationLibrarySpans.Spans
 
+	expectedSpansCount := 15
+
 	// there are 15 elements:
 	//   1 testsuites element (root element)
 	// 	 3 testsuite element
 	// 	 11 testcase elements
-	assert.Equal(t, 15, len(spans))
+	assert.Equal(t, expectedSpansCount, len(spans))
 
 	aTestCase := spans[2]
 	assert.Equal(t, "TestCheckConfigDirsCreatesWorkspaceAtHome", aTestCase.Name)
@@ -246,6 +248,10 @@ func Test_Main_SampleXML(t *testing.T) {
 
 	goVersion, _ := findAttributeInArray(aTestCase.Attributes, "go.version")
 	assertStringValueInAttribute(t, goVersion.Value, "go1.16.3 linux/amd64")
+
+	// last span is server type
+	aTestCase = spans[expectedSpansCount-1]
+	assert.Equal(t, "SPAN_KIND_SERVER", aTestCase.Kind)
 }
 
 func Test_GetServiceVariable(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -228,12 +228,12 @@ func Test_Main_SampleXML(t *testing.T) {
 
 	spans := instrumentationLibrarySpans.Spans
 
-	expectedSpansCount := 15
-
 	// there are 15 elements:
 	//   1 testsuites element (root element)
 	// 	 3 testsuite element
 	// 	 11 testcase elements
+	expectedSpansCount := 15
+
 	assert.Equal(t, expectedSpansCount, len(spans))
 
 	aTestCase := spans[2]

--- a/main_test.go
+++ b/main_test.go
@@ -201,7 +201,7 @@ func Test_Main_SampleXML(t *testing.T) {
 	}
 
 	// TODO: retry until the file is written by the otel-exporter
-	time.Sleep(time.Minute)
+	time.Sleep(time.Second * 30)
 
 	// assert using the generated file
 	jsonBytes, _ := ioutil.ReadFile(reportFilePath)

--- a/semconv.go
+++ b/semconv.go
@@ -12,6 +12,7 @@ const (
 
 	// scm keys
 	ScmAuthors    = "scm.authors"
+	ScmBaseRef    = "scm.baseRef"
 	ScmBranch     = "scm.branch"
 	ScmCommitters = "scm.committers"
 	ScmProvider   = "scm.provider"


### PR DESCRIPTION
## What does this PR do?
It does three things:
1. sets the outer span to be of Server kind, which means it will define that the current span will be cosnidered as an incoming new tracee in the distributed traces. The outer span is the one that happens before any test suite is processed
2. includes process information when defining the initial resource at tracer provider creation
3. it adds `scm.baseRef` for change requests, adding the target branch