### PR TITLE
feat: support passing the path of the SCM repository to be read

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This tool is able to override the following attributes:
 
 | Attribute | Flag | Default value | Description |
 | --------- | ---- | ------------- | ----------- |
+| Repository Path | --repository-path | `.` | Path to the SCM repository to be read. |
 | Service Name | --service-name | `junit2otlp` | Overrides OpenTelemetry's service name. If the `OTEL_SERVICE_NAME` environment variable is set, it will take precedence over any other value. |
 | Service Version | --service-version | Empty | Overrides OpenTelemetry's service version. If the `OTEL_SERVICE_VERSION` environment variable is set, it will take precedence over any other value. |
 | Trace Name | --trace-name | `junit2otlp` | Overrides OpenTelemetry's trace name. |
@@ -101,7 +102,7 @@ make demo-start-elastic
 
 3. Finally, once the services are started, run:
 ```
-cat TEST-sample3.xml | docker run --rm -i --network elastic_junit2otlp --env OTEL_EXPORTER_OTLP_ENDPOINT=http://apm-server:8200 mdelapenya/junit2otlp:latest --service-name DOCKERFOO --trace-name TRACEBAR
+cat TEST-sample3.xml | docker run --rm -i --network elastic_junit2otlp --volume "$(pwd):/opt/projectname" --env OTEL_EXPORTER_OTLP_ENDPOINT=http://apm-server:8200 mdelapenya/junit2otlp:latest --service-name DOCKERFOO --trace-name TRACEBAR --repository-path "/opt/projectname"
 ```
   - We are making the Docker container receive the pipe with the `-i` flag.
   - We are attaching the container to the same Docker network where the services are running.

--- a/main.go
+++ b/main.go
@@ -35,12 +35,7 @@ var traceNameFlag string
 var runtimeAttributes []attribute.KeyValue
 
 func init() {
-	workingDir, err := os.Getwd()
-	if err != nil {
-		workingDir = "."
-	}
-
-	flag.StringVar(&repositoryPathFlag, "repository-path", workingDir, "Path to the SCM repository to be read")
+	flag.StringVar(&repositoryPathFlag, "repository-path", getDefaultwd(), "Path to the SCM repository to be read")
 	flag.StringVar(&serviceNameFlag, "service-name", Junit2otlp, "OpenTelemetry Service Name to be used when sending traces and metrics for the jUnit report")
 	flag.StringVar(&serviceVersionFlag, "service-version", "", "OpenTelemetry Service Version to be used when sending traces and metrics for the jUnit report")
 	flag.StringVar(&traceNameFlag, "trace-name", Junit2otlp, "OpenTelemetry Trace Name to be used when sending traces and metrics for the jUnit report")
@@ -130,6 +125,16 @@ func createTracesAndSpans(ctx context.Context, srvName string, tracesProvides *s
 	}
 
 	return nil
+}
+
+// getDefaultwd retrieves the current working dir, using '.' in the case an error occurs
+func getDefaultwd() string {
+	workingDir, err := os.Getwd()
+	if err != nil {
+		return "."
+	}
+
+	return workingDir
 }
 
 // getOtlpEnvVar checks if the env variable, removing the OTEL prefix, needs to override

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+var repositoryPathFlag string
 var serviceNameFlag string
 var serviceVersionFlag string
 var traceNameFlag string
@@ -34,6 +35,12 @@ var traceNameFlag string
 var runtimeAttributes []attribute.KeyValue
 
 func init() {
+	workingDir, err := os.Getwd()
+	if err != nil {
+		workingDir = "."
+	}
+
+	flag.StringVar(&repositoryPathFlag, "repository-path", workingDir, "Path to the SCM repository to be read")
 	flag.StringVar(&serviceNameFlag, "service-name", Junit2otlp, "OpenTelemetry Service Name to be used when sending traces and metrics for the jUnit report")
 	flag.StringVar(&serviceVersionFlag, "service-version", "", "OpenTelemetry Service Version to be used when sending traces and metrics for the jUnit report")
 	flag.StringVar(&traceNameFlag, "trace-name", Junit2otlp, "OpenTelemetry Trace Name to be used when sending traces and metrics for the jUnit report")
@@ -57,7 +64,7 @@ func createTracesAndSpans(ctx context.Context, srvName string, tracesProvides *s
 	tracer := tracesProvides.Tracer(srvName)
 	meter := global.Meter(srvName)
 
-	scm := GetScm()
+	scm := GetScm(repositoryPathFlag)
 	if scm != nil {
 		scmAttributes := scm.contributeAttributes()
 		runtimeAttributes = append(runtimeAttributes, scmAttributes...)

--- a/scm.go
+++ b/scm.go
@@ -11,18 +11,13 @@ type Scm interface {
 
 // GetScm checks if the underlying filesystem repository is a Git repository
 // checking the existence of the .git directory in the current workspace
-func GetScm() Scm {
+func GetScm(repoDir string) Scm {
 	// if .git file exists
-	workingDir, err := os.Getwd()
-	if err != nil {
-		return nil
-	}
-
-	_, err = os.Stat(path.Join(workingDir, ".git"))
+	_, err := os.Stat(path.Join(repoDir, ".git"))
 	if os.IsNotExist(err) {
 		return nil
 	}
 
 	// .git exists
-	return NewGitScm(workingDir)
+	return NewGitScm(repoDir)
 }

--- a/scm_test.go
+++ b/scm_test.go
@@ -1,17 +1,31 @@
 package main
 
 import (
+	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetScm(t *testing.T) {
 	t.Run("This project uses Git", func(t *testing.T) {
-		scm := GetScm()
+		workingDir, err := os.Getwd()
+		if err != nil {
+			workingDir = "."
+		}
+
+		scm := GetScm(workingDir)
 		switch scm.(type) {
 		case *GitScm:
 			// NOOP
 		default:
 			t.Error()
 		}
+	})
+
+	t.Run("This project does not use Git", func(t *testing.T) {
+		scm := GetScm(t.TempDir())
+
+		assert.Nil(t, scm, "The directory should not contain a .git directory")
 	})
 }

--- a/scm_test.go
+++ b/scm_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,12 +8,7 @@ import (
 
 func TestGetScm(t *testing.T) {
 	t.Run("This project uses Git", func(t *testing.T) {
-		workingDir, err := os.Getwd()
-		if err != nil {
-			workingDir = "."
-		}
-
-		scm := GetScm(workingDir)
+		scm := GetScm(getDefaultwd())
 		switch scm.(type) {
 		case *GitScm:
 			// NOOP


### PR DESCRIPTION
## What does this PR do?
It adds a flag to pass the path to the SCM repository to be read, in the case it resides in a different location (i.e. running the CLI in a dockerised format)


The repo path will be passed to the SCM factory that retrieves the SCM by type (only Git supported at this moment), using the current directory as default (keeps current behaviour)

## Why is it important?
While testing the CLI in a CI pipeline where the Dockerised version of the tool is used, we noticed the SCM attributes were not contributed, and this was caused because we were passing the content of the JUnit file, only. We need to mount a volume with the project dir and pass the new flag pointing to the mounted path inside the container.


