### PR TITLE
fix: flags must override env vars

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ var runtimeAttributes []attribute.KeyValue
 
 func init() {
 	flag.StringVar(&repositoryPathFlag, "repository-path", getDefaultwd(), "Path to the SCM repository to be read")
-	flag.StringVar(&serviceNameFlag, "service-name", Junit2otlp, "OpenTelemetry Service Name to be used when sending traces and metrics for the jUnit report")
+	flag.StringVar(&serviceNameFlag, "service-name", "", "OpenTelemetry Service Name to be used when sending traces and metrics for the jUnit report")
 	flag.StringVar(&serviceVersionFlag, "service-version", "", "OpenTelemetry Service Version to be used when sending traces and metrics for the jUnit report")
 	flag.StringVar(&traceNameFlag, "trace-name", Junit2otlp, "OpenTelemetry Trace Name to be used when sending traces and metrics for the jUnit report")
 
@@ -138,24 +138,28 @@ func getDefaultwd() string {
 	return workingDir
 }
 
-// getOtlpEnvVar checks if the env variable, removing the OTEL prefix, needs to override
-func getOtlpEnvVar(key string, flag string) string {
+// getOtlpEnvVar the precedence order is: flag > env var > default
+func getOtlpEnvVar(key string, flag string, fallback string) string {
+	if flag != "" {
+		return flag
+	}
+
 	envVar := os.Getenv(key)
 	if envVar != "" {
 		return envVar
 	}
 
-	return flag
+	return fallback
 }
 
 // getOtlpServiceName checks the service name
 func getOtlpServiceName() string {
-	return getOtlpEnvVar("OTEL_SERVICE_NAME", serviceNameFlag)
+	return getOtlpEnvVar("OTEL_SERVICE_NAME", serviceNameFlag, Junit2otlp)
 }
 
 // getOtlpServiceVersion checks the service version
 func getOtlpServiceVersion() string {
-	return getOtlpEnvVar("OTEL_SERVICE_VERSION", serviceVersionFlag)
+	return getOtlpEnvVar("OTEL_SERVICE_VERSION", serviceVersionFlag, "")
 }
 
 func initMetricsExporter(ctx context.Context) (*otlpmetric.Exporter, error) {

--- a/main.go
+++ b/main.go
@@ -139,13 +139,13 @@ func getDefaultwd() string {
 }
 
 // getOtlpEnvVar checks if the env variable, removing the OTEL prefix, needs to override
-func getOtlpEnvVar(key string, fallback string) string {
+func getOtlpEnvVar(key string, flag string) string {
 	envVar := os.Getenv(key)
 	if envVar != "" {
 		return envVar
 	}
 
-	return fallback
+	return flag
 }
 
 // getOtlpServiceName checks the service name

--- a/main.go
+++ b/main.go
@@ -138,13 +138,13 @@ func getDefaultwd() string {
 	return workingDir
 }
 
-// getOtlpEnvVar the precedence order is: flag > env var > default
-func getOtlpEnvVar(key string, flag string, fallback string) string {
+// getOtlpEnvVar the precedence order is: flag > env var > fallback
+func getOtlpEnvVar(flag string, envVarKey string, fallback string) string {
 	if flag != "" {
 		return flag
 	}
 
-	envVar := os.Getenv(key)
+	envVar := os.Getenv(envVarKey)
 	if envVar != "" {
 		return envVar
 	}
@@ -154,12 +154,12 @@ func getOtlpEnvVar(key string, flag string, fallback string) string {
 
 // getOtlpServiceName checks the service name
 func getOtlpServiceName() string {
-	return getOtlpEnvVar("OTEL_SERVICE_NAME", serviceNameFlag, Junit2otlp)
+	return getOtlpEnvVar(serviceNameFlag, "OTEL_SERVICE_NAME", Junit2otlp)
 }
 
 // getOtlpServiceVersion checks the service version
 func getOtlpServiceVersion() string {
-	return getOtlpEnvVar("OTEL_SERVICE_VERSION", serviceVersionFlag, "")
+	return getOtlpEnvVar(serviceVersionFlag, "OTEL_SERVICE_VERSION", "")
 }
 
 func initMetricsExporter(ctx context.Context) (*otlpmetric.Exporter, error) {


### PR DESCRIPTION
## What does this PR do?
It changes the precedence order when reading OTEL_ env vars regarding the name and version of the service:

1. if the binary flag is passed, use it
2. else, if the OTEL_ variable is present, use it
3. else, use the defaults:
    - name: `junit2otlp`
    - version: empty string

