### PR TITLE
chore: bump Go version to 1.18

### DIFF
--- a/.github/workflows/go-releaser.yml
+++ b/.github/workflows/go-releaser.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
         id: go
 
       - name: Run Unit tests

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mdelapenya/junit2otlp
 
-go 1.17
+go 1.18
 
 require (
 	github.com/go-git/go-git/v5 v5.4.2


### PR DESCRIPTION
## What does this PR do?
It bumps the lang version from 1.17 (reached EOL) to 1.18

## Why is it important?
Dependabot PRs are failing
