### PR TITLE
chore(ci): add dependencies section

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -16,6 +16,9 @@ categories:
     labels:
       - 'docs'
       - 'documentation'
+  - title: '📦 Dependencies'
+    labels:
+      - 'dependencies'
   - title: '🧰 Maintenance'
     label: 'chore'
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'


### PR DESCRIPTION
Adds dependencies section to the release notes, thanks to a section in the release-drafter config file.

It'll use the `dependencies` GH label.
