### PR TITLE
Only run release on upstream repo

### DIFF
--- a/.github/workflows/go-releaser.yml
+++ b/.github/workflows/go-releaser.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   goreleaser:
+    if: github.repository == 'mdelapenya/junit2otlp'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   update_release_draft:
+    if: github.repository == 'mdelapenya/junit2otlp'
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"


### PR DESCRIPTION
In our fork we want tests to run on the PRs my coworkers are reviewing. This PR should ensure that tag and draft release GHA don't run on downstream repos. 