### PR TITLE
chore(deps): remove dependabot's reviewer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,6 @@ updates:
     directory: "/"
     labels:
       - "dependencies"
-    reviewers:
-      - "mdelapenya"
     schedule:
       interval: monthly
   - package-ecosystem: gomod
@@ -20,8 +18,6 @@ updates:
     directory: "/"
     labels:
       - "dependencies"
-    reviewers:
-      - "mdelapenya"
     schedule:
       interval: monthly
   - package-ecosystem: docker
@@ -32,7 +28,5 @@ updates:
     directory: "/"
     labels:
       - "dependencies"
-    reviewers:
-      - "mdelapenya"
     schedule:
       interval: monthly


### PR DESCRIPTION
Seehttps://github.com/mdelapenya/junit2otlp/pull/134#issuecomment-2927061346 and https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/